### PR TITLE
Simple logging system

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,11 +1,26 @@
 package frc.robot;
 
+import java.lang.System.Logger.Level;
+
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.util.Units;
 
 public final class Constants {
+
+    /**
+     * The LoggingConstants class holds the logging configuration for the robot.
+     * 
+     * <p>currentLogLevel: The current logging level for the robot's logging system.
+     * The log level determines the severity of messages that will be logged.
+     * Common log levels include DEBUG, INFO, WARN, and ERROR, with DEBUG being the most
+     * verbose and ERROR being the least.
+     */
+    public static final class LoggingConstants{
+        public static final Level CURRENT_LOG_LEVEL = Level.INFO;
+    }
+    
     public static final class ElevatorConstants {
         public static final int kElevatorMotorID = 0; // change later
         public static final double kElevatorGearRatio = 1/20; // 20 rotations of the motor to one shaft rotation

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -25,6 +26,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
+    // Start the DataLogManager
+    DataLogManager.start();
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();

--- a/src/main/java/frc/robot/extras/LogManager.java
+++ b/src/main/java/frc/robot/extras/LogManager.java
@@ -6,7 +6,21 @@ import java.io.StringWriter;
 import edu.wpi.first.wpilibj.DataLogManager;
 import frc.robot.Constants.LoggingConstants;
 
+
+/*
+Standard Data Logging using DataLogManager
+The DataLogManager class (Java, C++, Python) provides a centralized data log that provides automatic data log file management. It automatically cleans up old files when disk space is low and renames the file based either on current date/time or (if available) competition match number. The data file will be saved to a USB flash drive in a folder called logs if one is attached, or to /home/lvuser/logs otherwise.
+
+Note
+
+USB flash drives need to be formatted as FAT32 to work with the roboRIO. NTFS or exFAT formatted drives will not work. Flash drives of 32GB or smaller are recommended, as Windows doesn’t format drives larger then 32GB with FAT32.
+
+Log files are initially named FRC_TBD_{random}.wpilog until the DS connects. After the DS connects, the log file is renamed to FRC_yyyyMMdd_HHmmss.wpilog (where the date/time is UTC). If the FMS is connected and provides a match number, the log file is renamed to FRC_yyyyMMdd_HHmmss_{event}_{match}.wpilog.
+
+On startup, all existing log files where a DS has not been connected will be deleted. If there is less than 50 MB of free space on the target storage, FRC_ log files are deleted (oldest to newest) until there is 50 MB free OR there are 10 files remaining.
+ */
 public class LogManager {
+
 
     // Logs at this message should be our most granular and only used for debugging purposes
     public static void debug(String message) {
@@ -16,6 +30,7 @@ public class LogManager {
         }
     }
 
+    // we should be more cautious about logging here and avoid too much data - avoid info logging for things tied to constant updates
     public static void info(String message) {
         if (LoggingConstants.CURRENT_LOG_LEVEL.getSeverity() 
                 <= System.Logger.Level.INFO.getSeverity()) {

--- a/src/main/java/frc/robot/extras/LogManager.java
+++ b/src/main/java/frc/robot/extras/LogManager.java
@@ -1,0 +1,57 @@
+package frc.robot.extras;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import edu.wpi.first.wpilibj.DataLogManager;
+import frc.robot.Constants.LoggingConstants;
+
+public class LogManager {
+
+    // Logs at this message should be our most granular and only used for debugging purposes
+    public static void debug(String message) {
+        if (LoggingConstants.CURRENT_LOG_LEVEL.getSeverity() 
+                <= System.Logger.Level.DEBUG.getSeverity()) {
+            DataLogManager.log("DEBUG: " + message);
+        }
+    }
+
+    public static void info(String message) {
+        if (LoggingConstants.CURRENT_LOG_LEVEL.getSeverity() 
+                <= System.Logger.Level.INFO.getSeverity()) {
+            DataLogManager.log("INFO: " + message);
+        }
+    }
+
+    public static void warning(String message) {
+        if (LoggingConstants.CURRENT_LOG_LEVEL.getSeverity() 
+                <= System.Logger.Level.WARNING.getSeverity()) {
+            DataLogManager.log("WARNING: " + message);
+        }
+    }
+
+    public static void error(String message) {
+        if (LoggingConstants.CURRENT_LOG_LEVEL.getSeverity() 
+                <= System.Logger.Level.ERROR.getSeverity()) {
+            DataLogManager.log("ERROR: " + message);
+        }
+    }
+
+    // Overloaded error method that accepts a Throwable
+    public static void error(String message, Throwable throwable) {
+        if (LoggingConstants.CURRENT_LOG_LEVEL.getSeverity() 
+                <= System.Logger.Level.ERROR.getSeverity()) {
+            DataLogManager.log("ERROR: " + message + "\n" + stackTraceToString(throwable));
+        }
+    }
+
+    /**
+     * Helper method to convert a stack trace to a String.
+     */
+    private static String stackTraceToString(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        throwable.printStackTrace(pw);
+        return sw.toString();
+    }
+}


### PR DESCRIPTION
- starting with this as opposed to pulling advantage as that may pull in more than we need.
- wpi has a system for logging, but by default it will only:
   - "This will record all NetworkTables changes to the data log."
   - and, it will take a string log that we give it but as no concept of log levels
- added simple utility function that logs according to log level set in constants
- for extreme logging situations, trying to find difficult to find issues and we need as much visibility as we can get, lets we can log that extra detail with logDebug and if our current level is set to debug, that log will occur. 
- the above rule will allow that we can have a lot of logging throughout the app and if we change the level to info, we won't log any of the debug logs, only info, warning, and error - likewise we can eventually set it to only log warning and error if need be 
